### PR TITLE
Added consumer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ We support installation via composer, note for now you need to set the minimum s
 
 `composer require interactive-solutions/zf-bernard`
 
+## Usage
+
+To consume a queue:
+
+```bash
+$ php public/index interactive-solutions:bernard:consume <queueName>
+```
+
+You can also pass the following options:
+- `--max-runtime=<VALUE>`: This will make the consumer shutdown after `<VALUE>` seconds. PHP_INT_MAX by default
+- `--stop-on-failure`: This will make the consumer halt on unhandled exceptions. Off by default
+- `--max-messages=<VALUE>`: This will make the consumer shutdown after `<VALUE>` messages are ran. Infinite by default
+- `--stop-on-empty`: This will make the consumer run all the queued messages and then shutdown. Off by default
+
 ## Normalizers
 
 You can add any normalizer that you wish to use by adding it to the `BernardOptions::enabledNormalizers`

--- a/config/route.config.php
+++ b/config/route.config.php
@@ -15,7 +15,7 @@ return [
             'routes' => [
                 'bernard-consume' => [
                     'options' => [
-                        'route'    => 'interactive-solutions:bernard:consume [--max-runtime=] <queue>',
+                        'route'    => 'interactive-solutions:bernard:consume [--max-runtime=] [--stop-on-failure] [--stop-when-empty] [--max-messages=] <queue>',
                         'defaults' => [
                             'controller' => ConsoleController::class,
                             'action'     => 'consume',

--- a/src/Controller/ConsoleController.php
+++ b/src/Controller/ConsoleController.php
@@ -55,7 +55,10 @@ class ConsoleController extends AbstractConsoleController
         $queue = $this->queues->create($this->getRequest()->getParam('queue'));
 
         $this->consumer->consume($queue, [
-            'max-runtime' => $this->getRequest()->getParam('max-runtime'),
+            'max-runtime'     => $this->getRequest()->getParam('max-runtime', PHP_INT_MAX),
+            'stop-on-error'   => $this->getRequest()->getParam('stop-on-failure', false),
+            'max-messages'    => $this->getRequest()->getParam('max-messages', null),
+            'stop-when-empty' => $this->getRequest()->getParam('stop-when-empty', false)
         ]);
     }
 }


### PR DESCRIPTION
You can now also specify:
--stop-on-failure
--stop-when-empty
--max-messages
when starting the consumer
